### PR TITLE
Fix version conflicts caused by PR#165

### DIFF
--- a/AudioSensei/AudioSensei.csproj
+++ b/AudioSensei/AudioSensei.csproj
@@ -55,12 +55,12 @@
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.0-preview6" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0-preview6" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="0.10.0-preview6" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.0-preview6" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.0-preview6" />
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="0.10.0-preview6" />
+    <PackageReference Include="Avalonia" Version="0.10.6" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.6" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="0.10.6" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.6" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.6" />
+    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="0.10.6.10" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Avalonia.Xaml.Behaviors from 0.10.0-preview6 to 0.10.6.10. [(PR#165)](https://github.com/AudioSensei/AudioSensei/pull/165).
Hope this fix can help you.

Best regards,
sucrose